### PR TITLE
fix(): change script path for different OS

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,5 +1,8 @@
 ---
 
+- name: include preflight tasks
+  include: preflight.yaml
+
 # Install python-pip
 - name: Install python-pip | Debian
   apt: name=python-pip state=present
@@ -48,6 +51,6 @@
     weekday: "{{ elasticsearch_curator_cron_job.weekday|default('*') }}"
     month:   "{{ elasticsearch_curator_cron_job.month|default('*') }}"
     user:    "{{ elasticsearch_curator_cron_job.user|default('root') }}"
-    job:     "/usr/local/bin/curator --config {{ elasticsearch_curator_conf_dir }}/curator.yml {{ elasticsearch_curator_conf_dir }}/actions.yml"
+    job:     "{{ curator_bin_path }} --config {{ elasticsearch_curator_conf_dir }}/curator.yml {{ elasticsearch_curator_conf_dir }}/actions.yml"
     cron_file: elasticsearch-curator
   when: elasticsearch_curator_cron_job

--- a/tasks/preflight.yaml
+++ b/tasks/preflight.yaml
@@ -1,0 +1,14 @@
+---
+
+- name: preflight | include OS-specific variables
+  include_vars: "{{ item }}"
+  with_first_found:
+    - "{{ ansible_distribution }}-{{ ansible_distribution_major_version }}.yaml"
+    - "{{ ansible_distribution }}.yaml"
+    - "{{ ansible_os_family }}-{{ ansible_distribution_major_version }}.yaml"
+    - "{{ ansible_os_family }}.yaml"
+
+- name: preflight | define path for curator script file
+  set_fact:
+    curator_bin_path: "{{ __curator_bin_path }}"
+  when: curator_bin_path is not defined

--- a/vars/Debian.yaml
+++ b/vars/Debian.yaml
@@ -1,0 +1,3 @@
+---
+
+__curator_bin_path: /usr/local/bin/curator

--- a/vars/RedHat.yaml
+++ b/vars/RedHat.yaml
@@ -1,0 +1,3 @@
+---
+
+__curator_bin_path: /usr/bin/curator


### PR DESCRIPTION
Hi @wunzeco !

I tried your role for my several hosts (CentOS 7.5 and Ubuntu 16.04). I found some trouble for CentOS host.

When your role install task for cron, you use command like: "/usr/local/bin/curator --config .."

In my installation (on CentOS host) i found /usr/bin/curator and not found /usr/local/bin/curator.
In my installation (on Ubuntu host) i found /usr/local/bin/curator and not found /usr/bin/curator.

I added some changes for fix this behavior, please review it.

i used this vars for role:
elasticsearch_curator_version: 5.5.4

on this OS:
```
# cat /etc/redhat-release
CentOS Linux release 7.5.1804 (Core)
# whereis curator
curator: /usr/bin/curator
```

```
# lsb_release -a
No LSB modules are available.
Distributor ID:	Ubuntu
Description:	Ubuntu 16.04.4 LTS
Release:	16.04
Codename:	xenial
# whereis curator
curator: /usr/local/bin/curator
```

Thank you!
